### PR TITLE
Bounding Box caching

### DIFF
--- a/src/org/teaminfty/math_dragon/view/MathView.java
+++ b/src/org/teaminfty/math_dragon/view/MathView.java
@@ -514,6 +514,8 @@ public class MathView extends View
         @Override
         public boolean onScale(ScaleGestureDetector detector)
         {
+        	// Reset all the bounding boxes
+        	expression.validateAllBoundingBox(false);
             expressionDefaultHeight = Math.min(getResources().getDimensionPixelSize(R.dimen.math_object_max_default_size),
                     Math.max(expressionDefaultHeight * detector.getScaleFactor(), getResources().getDimensionPixelSize(R.dimen.math_object_min_default_size)));
             expression.setDefaultHeight((int) expressionDefaultHeight);
@@ -868,6 +870,9 @@ public class MathView extends View
                 
                 // Notify the listener of the change
                 expressionChanged();
+                
+                // Invalidate all bounding boxes of all expressions
+                expression.validateAllBoundingBox(false);
             }
         }
     }

--- a/src/org/teaminfty/math_dragon/view/math/Empty.java
+++ b/src/org/teaminfty/math_dragon/view/math/Empty.java
@@ -35,7 +35,7 @@ public class Empty extends Expression
     { return " "; }
     
     @Override
-    public Rect getChildBoundingBox(int index) throws IndexOutOfBoundsException
+    public Rect calculateChildBoundingBox(int index) throws IndexOutOfBoundsException
     {
         // Will always throw an error since empty boxes do not have children
         checkChildIndex(index);
@@ -69,7 +69,7 @@ public class Empty extends Expression
     }
     
     @Override
-    public Rect getBoundingBox()
+    public Rect calculateBoundingBox()
     {
     	int width = (int)(defaultHeight*RATIO);
     	int height = defaultHeight;
@@ -84,7 +84,7 @@ public class Empty extends Expression
     }
     
     @Override
-    public Rect[] getOperatorBoundingBoxes()
+    public Rect[] calculateOperatorBoundingBoxes()
     {
     	//emptyObjects don't have an operator, but they do need one for the drag and drop
     	

--- a/src/org/teaminfty/math_dragon/view/math/Parentheses.java
+++ b/src/org/teaminfty/math_dragon/view/math/Parentheses.java
@@ -49,7 +49,7 @@ public class Parentheses extends Expression
     }
     
     @Override
-    public Rect[] getOperatorBoundingBoxes()
+    public Rect[] calculateOperatorBoundingBoxes()
     {
     	final Rect childRect = getChild(0).getBoundingBox();
     	final int width = (int)(childRect.height() * RATIO);
@@ -59,7 +59,7 @@ public class Parentheses extends Expression
     }
     
     @Override
-    public Rect getBoundingBox()
+    public Rect calculateBoundingBox()
     {
     	final Rect childRect = getChild(0).getBoundingBox();
     	return new Rect(0, 0, 2 * (int)(childRect.height() * RATIO) + childRect.width(), childRect.height());
@@ -76,7 +76,7 @@ public class Parentheses extends Expression
     }
 
     @Override
-    public Rect getChildBoundingBox(int index) throws IndexOutOfBoundsException
+    public Rect calculateChildBoundingBox(int index) throws IndexOutOfBoundsException
     {
         // Check the child index
         checkChildIndex(index);

--- a/src/org/teaminfty/math_dragon/view/math/Symbol.java
+++ b/src/org/teaminfty/math_dragon/view/math/Symbol.java
@@ -167,14 +167,14 @@ public class Symbol extends Expression
     }
 
     @Override
-    public Rect[] getOperatorBoundingBoxes()
+    public Rect[] calculateOperatorBoundingBoxes()
     {
         // Find the right text size and return the bounding box for it
         return new Rect[]{ sizeAddPadding(getSize(findTextSize(level))) };
     }
 
     @Override
-    public Rect getChildBoundingBox(int index) throws IndexOutOfBoundsException
+    public Rect calculateChildBoundingBox(int index) throws IndexOutOfBoundsException
     {
         // Will always throw an error since constants do not have children
         checkChildIndex(index);

--- a/src/org/teaminfty/math_dragon/view/math/operation/Derivative.java
+++ b/src/org/teaminfty/math_dragon/view/math/operation/Derivative.java
@@ -103,7 +103,7 @@ public class Derivative extends Binary
     }
 
     @Override
-    public Rect[] getOperatorBoundingBoxes()
+    public Rect[] calculateOperatorBoundingBoxes()
     {
         // Get the sizes
         Rect[] sizes = getSizes();
@@ -125,7 +125,7 @@ public class Derivative extends Binary
     }
 
     @Override
-    public Rect getChildBoundingBox(int index) throws IndexOutOfBoundsException
+    public Rect calculateChildBoundingBox(int index) throws IndexOutOfBoundsException
     {
         // Make sure the child index is valid
         checkChildIndex(index);
@@ -151,7 +151,7 @@ public class Derivative extends Binary
     }
     
     @Override
-    public Rect getBoundingBox()
+    public Rect calculateBoundingBox()
     {
         // Get the sizes
         Rect[] sizes = getSizes();

--- a/src/org/teaminfty/math_dragon/view/math/operation/Function.java
+++ b/src/org/teaminfty/math_dragon/view/math/operation/Function.java
@@ -202,7 +202,7 @@ public class Function extends Expression
     }
     
     @Override
-    public Rect[] getOperatorBoundingBoxes() 
+    public Rect[] calculateOperatorBoundingBoxes() 
     {
         // Get the sizes
         final Rect childRect = getChild(0).getBoundingBox();
@@ -221,7 +221,7 @@ public class Function extends Expression
     }
     
     @Override
-    public Rect getChildBoundingBox(int index) throws IndexOutOfBoundsException 
+    public Rect calculateChildBoundingBox(int index) throws IndexOutOfBoundsException 
     {
         // Make sure the child index is valid
         checkChildIndex(index);
@@ -241,7 +241,7 @@ public class Function extends Expression
     
     //Complete bounding box
     @Override
-    public Rect getBoundingBox()
+    public Rect calculateBoundingBox()
     {
         Rect[] operatorSizes = getOperatorBoundingBoxes();
         Rect child = getChild(0).getBoundingBox();

--- a/src/org/teaminfty/math_dragon/view/math/operation/Integral.java
+++ b/src/org/teaminfty/math_dragon/view/math/operation/Integral.java
@@ -125,7 +125,7 @@ public class Integral extends Operation
 	
 	
 	@Override
-	public Rect[] getOperatorBoundingBoxes() {
+	public Rect[] calculateOperatorBoundingBoxes() {
 		
 		// Get all the sizes of the bounding boxes
 		Rect sizes[] = getSizes();
@@ -133,7 +133,7 @@ public class Integral extends Operation
 		int height = sizes[0].height();
 		
 		// Offset all the bounding boxes
-		sizes[0].offsetTo( horizontalOffset, sizes[5].height());
+		sizes[0].offsetTo( horizontalOffset, sizes[4].height());
 		sizes[3].offsetTo( horizontalOffset + sizes[0].width() + sizes[1].width(), sizes[4].height() + (height - sizes[3].height()) / 2);		
 		
 		// Return them
@@ -144,7 +144,7 @@ public class Integral extends Operation
 	}
 
 	@Override
-	public Rect getChildBoundingBox(int index) throws IndexOutOfBoundsException {
+	public Rect calculateChildBoundingBox(int index) throws IndexOutOfBoundsException {
 		// Get the sizes of the bounding boxes
 		Rect[] sizes = getSizes();
 		
@@ -179,7 +179,7 @@ public class Integral extends Operation
 	
 	
 	@Override
-    public Rect getBoundingBox()
+    public Rect calculateBoundingBox()
     {
         // Get the sizes
         Rect[] sizes = getSizes();

--- a/src/org/teaminfty/math_dragon/view/math/operation/Limit.java
+++ b/src/org/teaminfty/math_dragon/view/math/operation/Limit.java
@@ -110,14 +110,14 @@ public class Limit extends Operation
     }
 
     @Override
-    public Rect[] getOperatorBoundingBoxes()
+    public Rect[] calculateOperatorBoundingBoxes()
     {
         // TODO Auto-generated method stub
         throw new RuntimeException("stub");
     }
 
     @Override
-    public Rect getChildBoundingBox(int index) throws IndexOutOfBoundsException
+    public Rect calculateChildBoundingBox(int index) throws IndexOutOfBoundsException
     {
         // TODO Auto-generated method stub
         throw new RuntimeException("stub");

--- a/src/org/teaminfty/math_dragon/view/math/operation/binary/Divide.java
+++ b/src/org/teaminfty/math_dragon/view/math/operation/binary/Divide.java
@@ -66,7 +66,7 @@ public class Divide extends Binary
     }
 
     @Override
-    public Rect[] getOperatorBoundingBoxes()
+    public Rect[] calculateOperatorBoundingBoxes()
     {
         // Get the sizes
         Rect[] sizes = getSizes();
@@ -77,7 +77,7 @@ public class Divide extends Binary
     }
 
     @Override
-    public Rect getChildBoundingBox(int index) throws IndexOutOfBoundsException
+    public Rect calculateChildBoundingBox(int index) throws IndexOutOfBoundsException
     {
         // Make sure the child index is valid
         checkChildIndex(index);
@@ -99,7 +99,7 @@ public class Divide extends Binary
     }
     
     @Override
-    public Rect getBoundingBox()
+    public Rect calculateBoundingBox()
     {
         // Get the sizes
         Rect[] sizes = getSizes();

--- a/src/org/teaminfty/math_dragon/view/math/operation/binary/Linear.java
+++ b/src/org/teaminfty/math_dragon/view/math/operation/binary/Linear.java
@@ -35,7 +35,7 @@ public abstract class Linear extends Binary
     }
 
     @Override
-    public Rect[] getOperatorBoundingBoxes()
+    public Rect[] calculateOperatorBoundingBoxes()
     {
         // Get the operator size and the size of the left child
         Rect operatorSize = getOperatorSize();
@@ -50,7 +50,7 @@ public abstract class Linear extends Binary
     }
 
     @Override
-    public Rect getChildBoundingBox(int index) throws IndexOutOfBoundsException
+    public Rect calculateChildBoundingBox(int index) throws IndexOutOfBoundsException
     {
         // Make sure the child index is valid
         checkChildIndex(index);
@@ -92,7 +92,7 @@ public abstract class Linear extends Binary
     }
     
     @Override
-    public Rect getBoundingBox()
+    public Rect calculateBoundingBox()
     {
         // Get the sizes
         Rect operatorSize = getOperatorSize();

--- a/src/org/teaminfty/math_dragon/view/math/operation/binary/Power.java
+++ b/src/org/teaminfty/math_dragon/view/math/operation/binary/Power.java
@@ -82,7 +82,7 @@ public class Power extends Binary
     }
 
     @Override
-    public Rect[] getOperatorBoundingBoxes() 
+    public Rect[] calculateOperatorBoundingBoxes() 
     {
         // Get the children sizes
         Rect[] sizes = getChildrenSize();
@@ -115,7 +115,7 @@ public class Power extends Binary
     }
 
     @Override
-    public Rect getBoundingBox()
+    public Rect calculateBoundingBox()
     {
         // Get the sizes
         Rect[] sizes = getChildrenSize();
@@ -125,7 +125,7 @@ public class Power extends Binary
     }
     
     @Override
-    public Rect getChildBoundingBox(int index) throws IndexOutOfBoundsException 
+    public Rect calculateChildBoundingBox(int index) throws IndexOutOfBoundsException 
     {
         // Check if the child exists
         this.checkChildIndex(index);

--- a/src/org/teaminfty/math_dragon/view/math/operation/binary/Root.java
+++ b/src/org/teaminfty/math_dragon/view/math/operation/binary/Root.java
@@ -75,7 +75,7 @@ public class Root extends Binary
     }
 
     @Override
-    public Rect[] getOperatorBoundingBoxes() 
+    public Rect[] calculateOperatorBoundingBoxes() 
     {
         // Get the bounding boxes (not the sizes) of the children
         Rect exponentBounding = getChildBoundingBox(0);
@@ -93,7 +93,7 @@ public class Root extends Binary
     }
 
     @Override
-    public Rect getBoundingBox()
+    public Rect calculateBoundingBox()
     {
         // Get the bounding box (not the size) of the base
         Rect baseBounding = getChildBoundingBox(1);
@@ -103,7 +103,7 @@ public class Root extends Binary
     }
     
     @Override
-    public Rect getChildBoundingBox(int index) throws IndexOutOfBoundsException 
+    public Rect calculateChildBoundingBox(int index) throws IndexOutOfBoundsException 
     {
         // Check if the child exists
         checkChildIndex(index);


### PR DESCRIPTION
Added caching with the bounding boxes. Bounding box calculations still need optimalization, which I will do, but this is still a nice performance boost when you are hovering over the equation. Zooming in/out and dropping an operator is still slow due to the unoptimized bounding box calculations.

Signed-off-by: bvanr henkibrij@hotmail.com
